### PR TITLE
WIP: Added the docker namespacing functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2018-12-21 [Feature] Add fine-grain control of docker image namespace
 - 2018-12-02 [Feature] Download extra locales from [openedx-i18n](https://github.com/regisb/openedx-i18n/) to the Open edX Docker image
 - 2018-11-28 [Feature] Easily change openedx docker image
 - 2018-11-28 [Feature] Enable comprehensive theming!

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To renew the certificate, run this command once per month:
 
 ### Student notes
 
-With [notes](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/exercises_tools/notes.html?highlight=notes), students can annotate portions of the courseware. 
+With [notes](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/exercises_tools/notes.html?highlight=notes), students can annotate portions of the courseware.
 
 ![Notes in action](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/_images/SFD_SN_bodyexample.png)
 
@@ -87,7 +87,7 @@ By default, the install script will collect some information about your install 
 
     export DISABLE_STATS=1
 
-If you decide to disable stats, please send me a message to tell me about your platform! 
+If you decide to disable stats, please send me a message to tell me about your platform!
 
 ## Requirements
 
@@ -254,7 +254,7 @@ This will open a shell in the LMS (or CMS) container. You can then run just any 
 The images are built, tagged and uploaded to Docker Hub in one command:
 
     make dockerhub
-  
+
 ## Help/Troubleshooting
 
 ### How to add custom themes?
@@ -289,9 +289,11 @@ Note that your release must be a fork of Hawthorn in order to work. Otherwise, y
 
 Add the following content to the `.env` file:
 
-    OPENEDX_DOCKER_IMAGE=myusername/myimage:mytag
+    OPENEDX_DOCKER_NAMESPACE=<Docker Image Namespace>
+    OPENEDX_DOCKER_IMAGE_PREFIX=<Prefix for Image Name>
+    OPENEDX_DOCKER_TAG=<Docker Tag Name>
 
-Note that the `make build` and `make push` command will no longer work.
+You can change the namespace for the docker image by changing `OPENEDX_DOCKER_NAMESPACE`. This is useful if you would like to change the user the docker images are pushed to.
 
 ### "Cannot start service nginx: driver failed programming external connectivity"
 
@@ -322,7 +324,7 @@ You can identify which containers are consuming most resources by running:
 
 ### "Running migrations... Killed!"
 
-The LMS and CMS containers require at least 4 GB RAM, in particular to run the Open edX SQL migrations. On Docker for Mac, by default, containers are allocated at most 2 GB of RAM. On Mac OS, if the `make all` command dies after displaying "Running migrations", you most probably need to increase the allocated RAM. [Follow these instructions from the official Docker documentation](https://docs.docker.com/docker-for-mac/#advanced). 
+The LMS and CMS containers require at least 4 GB RAM, in particular to run the Open edX SQL migrations. On Docker for Mac, by default, containers are allocated at most 2 GB of RAM. On Mac OS, if the `make all` command dies after displaying "Running migrations", you most probably need to increase the allocated RAM. [Follow these instructions from the official Docker documentation](https://docs.docker.com/docker-for-mac/#advanced).
 
 
 ### `Build failed running pavelib.servers.lms: Subprocess return code: 1`

--- a/docker-compose-android.yml
+++ b/docker-compose-android.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   android:
-    image: regis/openedx-android:latest
+    image: $(OPENEDX_DOCKER_NAMESPACE:-regis)/$(OPENEDX_DOCKER_IMAGE_PREFIX:-'')openedx-android:$(OPENEDX_DOCKER_TAG:-hawthorn)
     build:
       context: ./android
     volumes:

--- a/docker-compose-notes.yml
+++ b/docker-compose-notes.yml
@@ -3,7 +3,7 @@ services:
 
   ############# Notes: backend store for edX Student Notes
   notes:
-    image: regis/openedx-notes:hawthorn
+    image: $(OPENEDX_DOCKER_NAMESPACE:-regis)/$(OPENEDX_DOCKER_IMAGE_PREFIX:-'')openedx-notes:$(OPENEDX_DOCKER_TAG:-hawthorn)
     build:
       context: ./notes
     networks:

--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -3,7 +3,7 @@ services:
 
   ############# Xqueue: external grading of Open edX problems
   xqueue:
-    image: regis/openedx-xqueue:hawthorn
+    image: $(OPENEDX_DOCKER_NAMESPACE:-regis)/$(OPENEDX_DOCKER_IMAGE_PREFIX:-'')openedx-xqueue:$(OPENEDX_DOCKER_TAG:-hawthorn)
     build:
       context: ./xqueue
     volumes:
@@ -14,7 +14,7 @@ services:
       - mysql
 
   xqueue_consumer:
-    image: regis/openedx-xqueue:hawthorn
+    image: $(OPENEDX_DOCKER_NAMESPACE:-regis)/$(OPENEDX_DOCKER_IMAGE_PREFIX:-'')openedx-xqueue:$(OPENEDX_DOCKER_TAG:-hawthorn)
     build:
       context: ./xqueue
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   ############# Forum
 
   forum:
-    image: regis/openedx-forum:hawthorn
+    image: ${OPENEDX_DOCKER_NAMESPACE:-regis}/${OPENEDX_DOCKER_IMAGE_PREFIX:-''}openedx-forum:${OPENEDX_DOCKER_TAG:-hawthorn}
     build:
       context: ./forum
     environment:
@@ -78,7 +78,7 @@ services:
   ############# LMS and CMS
 
   lms:
-    image: ${OPENEDX_DOCKER_IMAGE:-regis/openedx:hawthorn}
+    image: ${OPENEDX_DOCKER_NAMESPACE:-regis}/${OPENEDX_DOCKER_IMAGE_PREFIX:-''}openedx:${OPENEDX_DOCKER_TAG:-hawthorn}
     build:
       context: ./openedx
     environment:
@@ -98,7 +98,7 @@ services:
       - smtp
 
   cms:
-    image: ${OPENEDX_DOCKER_IMAGE:-regis/openedx:hawthorn}
+    image: ${OPENEDX_DOCKER_NAMESPACE:-regis}/${OPENEDX_DOCKER_IMAGE_PREFIX:-''}openedx:${OPENEDX_DOCKER_TAG:-hawthorn}
     build:
       context: ./openedx
     environment:
@@ -119,7 +119,7 @@ services:
 
   # We could probably create one service per queue here. For small instances, it is not necessary.
   lms_worker:
-    image: ${OPENEDX_DOCKER_IMAGE:-regis/openedx:hawthorn}
+    image: ${OPENEDX_DOCKER_NAMESPACE:-regis}/${OPENEDX_DOCKER_IMAGE_PREFIX:-''}openedx:${OPENEDX_DOCKER_TAG:-hawthorn}
     build:
       context: ./openedx
     environment:
@@ -135,7 +135,7 @@ services:
       - lms
 
   cms_worker:
-    image: ${OPENEDX_DOCKER_IMAGE:-regis/openedx:hawthorn}
+    image: ${OPENEDX_DOCKER_NAMESPACE:-regis}/${OPENEDX_DOCKER_IMAGE_PREFIX:-''}openedx:${OPENEDX_DOCKER_TAG:-hawthorn}
     build:
       context: ./openedx
     environment:


### PR DESCRIPTION
This feature branch adds the ability to add custom namespacing to the docker images that are built with this project. 

## API changes

This removes the existing variable `OPENEDX_DOCKER_IMAGE` and replaces it with individual pieces that allow for finer control. The new variables are also set to work with the makefile so `make build` (and other docker image commands) will continue to work.

The new variables are:

```
OPENEDX_DOCKER_NAMESPACE
OPENEDX_DOCKER_IMAGE_PREFIX
OPENEDX_DOCKER_TAG
```

These have defaults values that are backward compatible with the current default docker image. 