### PR TITLE
Fix SSL issue with the custom readthedocs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Quickstart
 Documentation
 -------------
 
-Extensive documentation is available online: https://docs.tutor.overhang.io/
+Extensive documentation is available online: https://tutor.readthedocs.io/
 
 How to contribute
 -----------------


### PR DESCRIPTION
```
$ curl https://docs.tutor.overhang.io/
curl: (51) SSL: certificate subject name (*.readthedocs.io)
does not match target host name 'docs.tutor.overhang.io'
```

Fixing it with readthedocs is one option, the other one is to fix the link in README.