### PR TITLE
fix VIDEO_IMAGE_SETTINGS and VIDEO_TRANSCRIPTS_SETTINGS path when export a course

### DIFF
--- a/deploy/local/templates/docker-compose.yml
+++ b/deploy/local/templates/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     volumes:
       - ../env/nginx:/etc/nginx/conf.d/
       - ../../data/openedx:/var/www/openedx:ro
+      - ../../data/cms:/openedx/data/cms/
+      - ../../data/lms:/openedx/data/lms/
       - ../../data/letsencrypt:/etc/letsencrypt/:ro
     depends_on:
       - lms

--- a/deploy/templates/nginx/cms.conf
+++ b/deploy/templates/nginx/cms.conf
@@ -42,6 +42,12 @@ server {
     try_files $uri @proxy_to_cms_app;
   }
 
+  location ~ ^/media/(?P<file>.*) {
+    root /openedx/data/cms/uploads;
+    try_files /$file =404;
+    expires 31536000s;
+  }
+
   location ~ ^/static/(?P<file>.*) {
     root /var/www/openedx;
     try_files /staticfiles/$file /course_static/$file =404;

--- a/deploy/templates/openedx/settings/cms/production.py
+++ b/deploy/templates/openedx/settings/cms/production.py
@@ -6,6 +6,36 @@ update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
 
 MEDIA_ROOT = "/openedx/data/uploads/"
 
+########################## VIDEO IMAGE STORAGE ############################
+
+VIDEO_IMAGE_SETTINGS = dict(
+    VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
+    VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX='video-images/',
+)
+
+########################## VIDEO TRANSCRIPTS STORAGE ############################
+
+VIDEO_TRANSCRIPTS_SETTINGS = dict(
+    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX='video-transcripts/',
+)
+
+
 # Change syslog-based loggers which don't work inside docker containers
 LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
 LOGGING['handlers']['tracking'] = {

--- a/deploy/templates/openedx/settings/lms/production.py
+++ b/deploy/templates/openedx/settings/lms/production.py
@@ -8,6 +8,36 @@ update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
 # Set uploaded media file path
 MEDIA_ROOT = "/openedx/data/uploads/"
 
+########################## VIDEO IMAGE STORAGE ############################
+
+VIDEO_IMAGE_SETTINGS = dict(
+    VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
+    VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX='video-images/',
+)
+
+########################## VIDEO TRANSCRIPTS STORAGE ############################
+
+VIDEO_TRANSCRIPTS_SETTINGS = dict(
+    VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
+    # Backend storage
+    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
+    STORAGE_KWARGS=dict(
+        location=MEDIA_ROOT,
+        base_url=MEDIA_URL,
+    ),
+    DIRECTORY_PREFIX='video-transcripts/',
+)
+
+
 # Change syslog-based loggers which don't work inside docker containers
 LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
 LOGGING['handlers']['tracking'] = {


### PR DESCRIPTION
The srt upload well, but when we export a course this fails. It's because the VIDEO_TRANSCRIPTS_SETTINGS var in common.py. This took the MEDIA_ROOT var from his own file (/edx/var/edxapp/media/) and upload the srt file on it. But this path is not a volume, then it`s only exists in one service(cms_worker) and when export ocurrs this search the file on cms service. The same with VIDEO_IMAGE_SETTINGS.
This fix redefine those vars on production.py with the correct path (/openedx/data/uploads/video-transcripts)