### PR TITLE
Tell openedx gunicorn to fork workers based on CPU count

### DIFF
--- a/tutor/templates/build/notes/Dockerfile
+++ b/tutor/templates/build/notes/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /openedx/edx-notes-api
 RUN pip install -r requirements/base.txt
 
 EXPOSE 8000
-CMD gunicorn --name notes --bind=0.0.0.0:8000 --max-requests=1000 notesserver.wsgi:application
+CMD gunicorn --workers=3 --name notes --bind=0.0.0.0:8000 --max-requests=1000 notesserver.wsgi:application

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -89,6 +89,9 @@ ENV SETTINGS tutor.production
 # Entrypoint will fix permissions of all files and run commands as openedx
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+# Copy gunicorn settings file
+COPY gunicorn_conf.py /openedx/gunicorn_conf.py
+
 # Run server
 EXPOSE 8000
-CMD gunicorn --name ${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application
+CMD gunicorn -c file:/openedx/gunicorn_conf.py --name ${SERVICE_VARIANT} --bind=0.0.0.0:8000 --max-requests=1000 ${SERVICE_VARIANT}.wsgi:application

--- a/tutor/templates/build/openedx/gunicorn_conf.py
+++ b/tutor/templates/build/openedx/gunicorn_conf.py
@@ -1,0 +1,5 @@
+import multiprocessing
+
+# The recommended number of workers is twice the
+# CPU count plus one
+workers = (multiprocessing.cpu_count()-1) * 2 + 2

--- a/tutor/templates/build/openedx/gunicorn_conf.py
+++ b/tutor/templates/build/openedx/gunicorn_conf.py
@@ -2,4 +2,4 @@ import multiprocessing
 
 # The recommended number of workers is twice the
 # CPU count plus one
-workers = (multiprocessing.cpu_count()-1) * 2 + 2
+workers = (multiprocessing.cpu_count() * 2) + 1

--- a/tutor/templates/build/xqueue/Dockerfile
+++ b/tutor/templates/build/xqueue/Dockerfile
@@ -6,10 +6,10 @@ RUN apt update && \
   apt install -y language-pack-en git python-pip libmysqlclient-dev
 
 RUN mkdir /openedx
-RUN git clone https://github.com/edx/xqueue --branch open-release/ironwood.1 --depth 1 /openedx/xqueue 
+RUN git clone https://github.com/edx/xqueue --branch open-release/ironwood.1 --depth 1 /openedx/xqueue
 WORKDIR /openedx/xqueue
 
 RUN pip install -r requirements.txt
 
 EXPOSE 8040
-CMD gunicorn --name xqueue --bind=0.0.0.0:8040 --max-requests=1000 xqueue.wsgi:application
+CMD gunicorn --workers=3 --name xqueue --bind=0.0.0.0:8040 --max-requests=1000 xqueue.wsgi:application


### PR DESCRIPTION
Tutor currently runs a single worker `gunicorn` process.

This PR makes the number of workers dependent on the number of cores: `(2 x $num_cores) + 1`, as recommended in the [gunicorn documentation](http://docs.gunicorn.org/en/stable/design.html#how-many-workers).