### PR TITLE
Log to files instead of docker logs

### DIFF
--- a/tutor/templates/apps/nginx/cms.conf
+++ b/tutor/templates/apps/nginx/cms.conf
@@ -22,7 +22,7 @@ server {
   client_max_body_size 100M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
-  
+
   # Disables server version feedback on pages and in headers
   server_tokens off;
   # Prevent invalid display courseware in IE 10+ with high privacy settings
@@ -71,4 +71,6 @@ server {
     # Expire other static files immediately (there should be very few / none of these)
     expires epoch;
   }
+  error_log   /var/log/openedx/cms_error.log warn;
+  access_log  /var/log/openedx/cms_access.log main;
 }

--- a/tutor/templates/apps/nginx/lms.conf
+++ b/tutor/templates/apps/nginx/lms.conf
@@ -22,7 +22,7 @@ server {
   client_max_body_size 4M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
-  
+
   # Disables server version feedback on pages and in headers
   server_tokens off;
   # Prevent invalid display courseware in IE 10+ with high privacy settings
@@ -87,4 +87,6 @@ server {
     # Expire other static files immediately (there should be very few / none of these)
     expires epoch;
   }
+  error_log   /var/log/openedx/lms_error.log warn;
+  access_log  /var/log/openedx/lms_access.log main;
 }

--- a/tutor/templates/apps/openedx/settings/cms/common.py
+++ b/tutor/templates/apps/openedx/settings/cms/common.py
@@ -1,7 +1,12 @@
 """Settings shared between production and development
 """
+# This file is not supposed to be imported, but rather exec'd
+# pylint: disable=undefined-variable
 import os
 
+
+# Load module store settings from config files
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
 
 # Set uploaded media file path
 MEDIA_ROOT = "/openedx/data/uploads/"
@@ -12,7 +17,7 @@ VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 
 # Change syslog-based loggers which don't work inside docker containers
 LOGGING_DEFAULT_LEVEL = os.environ.get('OPENEDX_LOGLEVEL', 'INFO')
-settings.LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
+LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
 
 LOGGING_FILENAME = os.path.join(LOG_DIR,
     '{}.log'.format(os.environ.get('SERVICE_VARIANT', 'other')))

--- a/tutor/templates/apps/openedx/settings/cms/common.py
+++ b/tutor/templates/apps/openedx/settings/cms/common.py
@@ -1,5 +1,7 @@
 """Settings shared between production and development
 """
+import os
+
 
 # Set uploaded media file path
 MEDIA_ROOT = "/openedx/data/uploads/"
@@ -9,9 +11,21 @@ VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 
 # Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+LOGGING_DEFAULT_LEVEL = os.environ.get('OPENEDX_LOGLEVEL', 'INFO')
+settings.LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
+
+LOGGING_FILENAME = os.path.join(LOG_DIR,
+    '{}.log'.format(os.environ.get('SERVICE_VARIANT', 'other')))
+LOGGING['handlers']['local'] = {
+    'level': LOGGING_DEFAULT_LEVEL,
+    'class': 'logging.handlers.WatchedFileHandler',
+    'filename': LOGGING_FILENAME,
+    'formatter': 'standard',
+}
+
 LOGGING['handlers']['tracking'] = {
     'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
+    'class': 'logging.handlers.WatchedFileHandler',
+    'filename': os.path.join(LOG_DIR, 'tracking.log'),
     'formatter': 'standard',
 }

--- a/tutor/templates/apps/openedx/settings/cms/common.py
+++ b/tutor/templates/apps/openedx/settings/cms/common.py
@@ -1,8 +1,8 @@
 """Settings shared between production and development
 """
+import os
 # This file is not supposed to be imported, but rather exec'd
 # pylint: disable=undefined-variable
-import os
 
 
 # Load module store settings from config files

--- a/tutor/templates/apps/openedx/settings/cms/common.py
+++ b/tutor/templates/apps/openedx/settings/cms/common.py
@@ -1,0 +1,17 @@
+"""Settings shared between production and development
+"""
+
+# Set uploaded media file path
+MEDIA_ROOT = "/openedx/data/uploads/"
+
+# Video settings
+VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+
+# Change syslog-based loggers which don't work inside docker containers
+LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+LOGGING['handlers']['tracking'] = {
+    'level': 'DEBUG',
+    'class': 'logging.StreamHandler',
+    'formatter': 'standard',
+}

--- a/tutor/templates/apps/openedx/settings/cms/development.py
+++ b/tutor/templates/apps/openedx/settings/cms/development.py
@@ -1,10 +1,8 @@
 import os
 from cms.envs.devstack import *
-from .common import *
 
 
-# Load module store settings from config files
-update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+execfile(os.path.join(os.path.dirname(__file__), 'common.py'), globals())
 
 LOCALE_PATHS.append('/openedx/locale')
 

--- a/tutor/templates/apps/openedx/settings/cms/development.py
+++ b/tutor/templates/apps/openedx/settings/cms/development.py
@@ -1,23 +1,10 @@
 import os
 from cms.envs.devstack import *
+from .common import *
+
 
 # Load module store settings from config files
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
-
-# Set uploaded media file path
-MEDIA_ROOT = "/openedx/data/uploads/"
-
-# Video settings
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-
-# Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
-LOGGING['handlers']['tracking'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
-    'formatter': 'standard',
-}
 
 LOCALE_PATHS.append('/openedx/locale')
 

--- a/tutor/templates/apps/openedx/settings/cms/production.py
+++ b/tutor/templates/apps/openedx/settings/cms/production.py
@@ -1,21 +1,10 @@
 import os
 from cms.envs.production import *
+from .common import *
 
+
+# Load module store settings from config files
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
-
-MEDIA_ROOT = "/openedx/data/uploads/"
-
-# Video settings
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-
-# Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
-LOGGING['handlers']['tracking'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
-    'formatter': 'standard',
-}
 
 ALLOWED_HOSTS = [
     ENV_TOKENS.get('CMS_BASE'),

--- a/tutor/templates/apps/openedx/settings/cms/production.py
+++ b/tutor/templates/apps/openedx/settings/cms/production.py
@@ -1,10 +1,8 @@
 import os
 from cms.envs.production import *
-from .common import *
 
 
-# Load module store settings from config files
-update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+execfile(os.path.join(os.path.dirname(__file__), 'common.py'), globals())
 
 ALLOWED_HOSTS = [
     ENV_TOKENS.get('CMS_BASE'),

--- a/tutor/templates/apps/openedx/settings/lms/common.py
+++ b/tutor/templates/apps/openedx/settings/lms/common.py
@@ -1,3 +1,10 @@
+"""Settings shared between production and development
+"""
+import os
+# This file is not supposed to be imported, but rather exec'd
+# pylint: disable=undefined-variable
+
+
 # Set uploaded media file path
 MEDIA_ROOT = "/openedx/data/uploads/"
 
@@ -7,7 +14,7 @@ VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 
 # Change syslog-based loggers which don't work inside docker containers
 LOGGING_DEFAULT_LEVEL = os.environ.get('OPENEDX_LOGLEVEL', 'INFO')
-settings.LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
+LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
 
 LOGGING_FILENAME = os.path.join(LOG_DIR,
     '{}.log'.format(os.environ.get('SERVICE_VARIANT', 'other')))
@@ -23,6 +30,7 @@ LOGGING['handlers']['tracking'] = {
     'class': 'logging.handlers.WatchedFileHandler',
     'filename': os.path.join(LOG_DIR, 'tracking.log'),
     'formatter': 'standard',
+}
 
 # Fix media files paths
 VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT

--- a/tutor/templates/apps/openedx/settings/lms/common.py
+++ b/tutor/templates/apps/openedx/settings/lms/common.py
@@ -6,12 +6,23 @@ VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
 
 # Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
-LOGGING['handlers']['tracking'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
+LOGGING_DEFAULT_LEVEL = os.environ.get('OPENEDX_LOGLEVEL', 'INFO')
+settings.LOGGING['loggers']['']['level'] = LOGGING_DEFAULT_LEVEL
+
+LOGGING_FILENAME = os.path.join(LOG_DIR,
+    '{}.log'.format(os.environ.get('SERVICE_VARIANT', 'other')))
+LOGGING['handlers']['local'] = {
+    'level': LOGGING_DEFAULT_LEVEL,
+    'class': 'logging.handlers.WatchedFileHandler',
+    'filename': LOGGING_FILENAME,
     'formatter': 'standard',
 }
+
+LOGGING['handlers']['tracking'] = {
+    'level': 'DEBUG',
+    'class': 'logging.handlers.WatchedFileHandler',
+    'filename': os.path.join(LOG_DIR, 'tracking.log'),
+    'formatter': 'standard',
 
 # Fix media files paths
 VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT

--- a/tutor/templates/apps/openedx/settings/lms/common.py
+++ b/tutor/templates/apps/openedx/settings/lms/common.py
@@ -1,0 +1,19 @@
+# Set uploaded media file path
+MEDIA_ROOT = "/openedx/data/uploads/"
+
+# Video settings
+VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+
+# Change syslog-based loggers which don't work inside docker containers
+LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+LOGGING['handlers']['tracking'] = {
+    'level': 'DEBUG',
+    'class': 'logging.StreamHandler',
+    'formatter': 'standard',
+}
+
+# Fix media files paths
+VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
+PROFILE_IMAGE_BACKEND['options']['location'] = os.path.join(MEDIA_ROOT, 'profile-images/')

--- a/tutor/templates/apps/openedx/settings/lms/common.py
+++ b/tutor/templates/apps/openedx/settings/lms/common.py
@@ -4,6 +4,9 @@ import os
 # This file is not supposed to be imported, but rather exec'd
 # pylint: disable=undefined-variable
 
+# Load module store settings from config files
+update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+
 
 # Set uploaded media file path
 MEDIA_ROOT = "/openedx/data/uploads/"

--- a/tutor/templates/apps/openedx/settings/lms/development.py
+++ b/tutor/templates/apps/openedx/settings/lms/development.py
@@ -1,10 +1,8 @@
 import os
 from lms.envs.devstack import *
-from .common import *
 
 
-# Load module store settings from config files
-update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+execfile(os.path.join(os.path.dirname(__file__), 'common.py'), globals())
 
 ORA2_FILEUPLOAD_BACKEND = 'filesystem'
 ORA2_FILEUPLOAD_ROOT = '/openedx/data/ora2'

--- a/tutor/templates/apps/openedx/settings/lms/development.py
+++ b/tutor/templates/apps/openedx/settings/lms/development.py
@@ -1,28 +1,10 @@
 import os
 from lms.envs.devstack import *
+from .common import *
+
 
 # Load module store settings from config files
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
-
-# Set uploaded media file path
-MEDIA_ROOT = "/openedx/data/uploads/"
-
-# Video settings
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-
-# Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
-LOGGING['handlers']['tracking'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
-    'formatter': 'standard',
-}
-
-# Fix media files paths
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-PROFILE_IMAGE_BACKEND['options']['location'] = os.path.join(MEDIA_ROOT, 'profile-images/')
 
 ORA2_FILEUPLOAD_BACKEND = 'filesystem'
 ORA2_FILEUPLOAD_ROOT = '/openedx/data/ora2'

--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -1,10 +1,8 @@
 import os
 from lms.envs.production import *
-from .common import *
 
 
-# Load module store settings from config files
-update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
+execfile(os.path.join(os.path.dirname(__file__), 'common.py'), globals())
 
 ALLOWED_HOSTS = [
     ENV_TOKENS.get('LMS_BASE'),

--- a/tutor/templates/apps/openedx/settings/lms/production.py
+++ b/tutor/templates/apps/openedx/settings/lms/production.py
@@ -1,28 +1,10 @@
 import os
 from lms.envs.production import *
+from .common import *
+
 
 # Load module store settings from config files
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
-
-# Set uploaded media file path
-MEDIA_ROOT = "/openedx/data/uploads/"
-
-# Video settings
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-
-# Change syslog-based loggers which don't work inside docker containers
-LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
-LOGGING['handlers']['tracking'] = {
-    'level': 'DEBUG',
-    'class': 'logging.StreamHandler',
-    'formatter': 'standard',
-}
-
-# Fix media files paths
-VIDEO_IMAGE_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-VIDEO_TRANSCRIPTS_SETTINGS['STORAGE_KWARGS']['location'] = MEDIA_ROOT
-PROFILE_IMAGE_BACKEND['options']['location'] = os.path.join(MEDIA_ROOT, 'profile-images/')
 
 ALLOWED_HOSTS = [
     ENV_TOKENS.get('LMS_BASE'),

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/
       - ../apps/openedx/config/:/openedx/config/
       - ../../data/lms:/openedx/data
+      - ../../data/logs/lms:/openedx/data/logs
     depends_on:
       {% if ACTIVATE_ELASTICSEARCH %}- elasticsearch{% endif %}
       - forum
@@ -131,6 +132,7 @@ services:
       - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/
       - ../apps/openedx/config/:/openedx/config/
       - ../../data/cms:/openedx/data
+      - ../../data/logs/cms:/openedx/data/logs
     depends_on:
       {% if ACTIVATE_ELASTICSEARCH %}- elasticsearch{% endif %}
       {% if ACTIVATE_MEMCACHED %}- memcached{% endif %}
@@ -148,13 +150,14 @@ services:
       SERVICE_VARIANT: lms
       SETTINGS: ${EDX_PLATFORM_SETTINGS:-tutor.production}
       C_FORCE_ROOT: "1" # run celery tasks as root #nofear
-    command: ./manage.py lms celery worker --loglevel=info --hostname=edx.lms.core.default.%%h --maxtasksperchild 100
+    command: ./manage.py lms celery worker --loglevel=info --logfile=/openedx/data/logs/lms-worker.log  --hostname=edx.lms.core.default.%%h --maxtasksperchild 100
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/
       - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/
       - ../apps/openedx/config/:/openedx/config/
       - ../../data/lms:/openedx/data
+      - ../../data/logs/lms-worker:/openedx/data/logs
     depends_on:
       - lms
 
@@ -164,13 +167,14 @@ services:
       SERVICE_VARIANT: cms
       SETTINGS: ${EDX_PLATFORM_SETTINGS:-tutor.production}
       C_FORCE_ROOT: "1" # run celery tasks as root #nofear
-    command: ./manage.py cms celery worker --loglevel=info --hostname=edx.cms.core.default.%%h --maxtasksperchild 100
+    command: ./manage.py cms celery worker --loglevel=info --logfile=/openedx/data/logs/lms-worker.log --hostname=edx.cms.core.default.%%h --maxtasksperchild 100
     restart: unless-stopped
     volumes:
       - ../apps/openedx/settings/lms/:/openedx/edx-platform/lms/envs/tutor/
       - ../apps/openedx/settings/cms/:/openedx/edx-platform/cms/envs/tutor/
       - ../apps/openedx/config/:/openedx/config/
       - ../../data/cms:/openedx/data
+      - ../../data/logs/cms-worker:/openedx/data/logs
     depends_on:
       - cms
 

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - "{{ NGINX_HTTP_PORT }}:80"
       - "{{ NGINX_HTTPS_PORT }}:443"
     volumes:
+      - ../../data/logs/nginx:/var/log/openedx
       - ../apps/nginx:/etc/nginx/conf.d/
       - ../../data/openedx:/var/www/openedx:ro
       - ../../data/cms:/openedx/data/cms/:ro

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -22,9 +22,12 @@ services:
   {% if ACTIVATE_MYSQL %}
   mysql:
     image: {{ DOCKER_REGISTRY }}{{ DOCKER_IMAGE_MYSQL }}
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    command: |
+      mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+      --general-log=1 --general-log-file=/var/log/mysql/general-log.log
     restart: unless-stopped
     volumes:
+      - ../../data/logs/mysql:/var/log/mysql
       - ../../data/mysql:/var/lib/mysql
     env_file: ../apps/mysql/auth.env
   {% endif %}


### PR DESCRIPTION
This PR changes handling of logs by lms, cms, mysql and nginx so that they log to `${TUTOR_ROOT}/data/logs` instead of sending the logs to docker.

It includes an opinionated refactoring that should reduce code duplication. Should that part need further discussion I can revert it and PR it separately.