### PR TITLE
Fix database initialization

### DIFF
--- a/tutor/k8s.py
+++ b/tutor/k8s.py
@@ -66,7 +66,7 @@ def delete(yes):
 )
 @opts.root
 def databases(root):
-    scripts.migrate(root, run_bash)
+    scripts.migrate(root, run_sh)
 
 
 @click.command(help="Create an Open edX user and interactively set their password")
@@ -76,14 +76,14 @@ def databases(root):
 @click.argument("name")
 @click.argument("email")
 def createuser(root, superuser, staff, name, email):
-    scripts.create_user(root, run_bash, superuser, staff, name, email)
+    scripts.create_user(root, run_sh, superuser, staff, name, email)
 
 
 @click.command(help="Import the demo course")
 @opts.root
 def importdemocourse(root):
     click.echo(fmt.info("Importing demo course"))
-    scripts.import_demo_course(root, run_bash)
+    scripts.import_demo_course(root, run_sh)
     click.echo(fmt.info("Re-indexing courses"))
     indexcourses.callback(root)
 
@@ -93,7 +93,7 @@ def importdemocourse(root):
 def indexcourses(root):
     # Note: this is currently broken with "pymongo.errors.ConnectionFailure: [Errno 111] Connection refused"
     # I'm not quite sure the settings are correctly picked up. Which is weird because migrations work very well.
-    scripts.index_courses(root, run_bash)
+    scripts.index_courses(root, run_sh)
 
 
 @click.command(
@@ -176,8 +176,8 @@ class K8s:
         kubectl_no_fail("exec", "--namespace", self.NAMESPACE, "-it", podname, "--", *command)
 
 
-def run_bash(root, service, command):  # pylint: disable=unused-argument
-    K8s().execute(service, "bash", "-e", "-c", command)
+def run_sh(root, service, command):  # pylint: disable=unused-argument
+    K8s().execute(service, "sh", "-e", "-c", command)
 
 
 k8s.add_command(quickstart)

--- a/tutor/local.py
+++ b/tutor/local.py
@@ -129,7 +129,7 @@ def run(root, service, command, args):
 @opts.root
 def databases(root):
     init_mysql(root)
-    scripts.migrate(root, run_sh)
+    scripts.migrate(root, run_sh, exec_sh)
 
 
 def init_mysql(root):
@@ -295,6 +295,11 @@ def check_service_is_activated(config, service):
 def run_sh(root, service, command):
     config = tutor_config.load(root)
     docker_compose(root, config, "run", "--rm", service, "sh", "-e", "-c", command)
+
+
+def exec_sh(root, service, command):
+    config = tutor_config.load(root)
+    docker_compose(root, config, "exec", "-T", service, "sh", "-e", "-c", command)
 
 
 def docker_compose(root, config, *command):

--- a/tutor/local.py
+++ b/tutor/local.py
@@ -152,7 +152,6 @@ def init_mysql(root):
         # pylint: disable=unsupported-membership-test
         if b"MySQL init process done. Ready for start up." in mysql_logs:
             click.echo(fmt.info("MySQL database initialized"))
-            docker_compose(root, config, "stop", "mysql")
             return
         sleep(4)
 

--- a/tutor/local.py
+++ b/tutor/local.py
@@ -129,7 +129,7 @@ def run(root, service, command, args):
 @opts.root
 def databases(root):
     init_mysql(root)
-    scripts.migrate(root, run_bash)
+    scripts.migrate(root, run_sh)
 
 
 def init_mysql(root):
@@ -247,7 +247,7 @@ def logs(root, follow, tail, service):
 def createuser(root, superuser, staff, name, email):
     config = tutor_config.load(root)
     check_service_is_activated(config, "lms")
-    scripts.create_user(root, run_bash, superuser, staff, name, email)
+    scripts.create_user(root, run_sh, superuser, staff, name, email)
 
 
 @click.command(help="Import the demo course")
@@ -256,7 +256,7 @@ def importdemocourse(root):
     config = tutor_config.load(root)
     check_service_is_activated(config, "cms")
     click.echo(fmt.info("Importing demo course"))
-    scripts.import_demo_course(root, run_bash)
+    scripts.import_demo_course(root, run_sh)
     click.echo(fmt.info("Re-indexing courses"))
     indexcourses.callback(root)
 
@@ -266,7 +266,7 @@ def importdemocourse(root):
 def indexcourses(root):
     config = tutor_config.load(root)
     check_service_is_activated(config, "cms")
-    scripts.index_courses(root, run_bash)
+    scripts.index_courses(root, run_sh)
 
 
 @click.command(
@@ -292,9 +292,9 @@ def check_service_is_activated(config, service):
         raise exceptions.TutorError("This command may only be executed on the server where the {} is running".format(service))
 
 
-def run_bash(root, service, command):
+def run_sh(root, service, command):
     config = tutor_config.load(root)
-    docker_compose(root, config, "run", "--rm", service, "bash", "-e", "-c", command)
+    docker_compose(root, config, "run", "--rm", service, "sh", "-e", "-c", command)
 
 
 def docker_compose(root, config, *command):

--- a/tutor/scripts.py
+++ b/tutor/scripts.py
@@ -4,12 +4,12 @@ from . import config as tutor_config
 from . import env
 from . import fmt
 
-def migrate(root, run_func):
+def migrate(root, run_func, exec_func):
     config = tutor_config.load(root)
 
     click.echo(fmt.info("Creating all databases..."))
     # Note: run this only when lms is activated?
-    run_template(root, config, "lms", "create_databases.sh", run_func)
+    run_template(root, config, "mysql", "create_databases.sh", exec_func)
 
     if config["ACTIVATE_LMS"]:
         click.echo(fmt.info("Running lms migrations..."))

--- a/tutor/templates/build/openedx/bin/docker-entrypoint.sh
+++ b/tutor/templates/build/openedx/bin/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 export DJANGO_SETTINGS_MODULE=$SERVICE_VARIANT.envs.$SETTINGS
 USERID=${USERID:=0}
 
@@ -13,7 +13,7 @@ if [ "$USERID" -ne 0 ]
 
         # Run CMD as different user
         exec chroot --userspec="$USERID" --skip-chdir / env HOME=/openedx "$@"
-else 
+else
         # Run CMD as root (business as usual)
         exec "$@"
 fi

--- a/tutor/templates/local/docker-compose.yml
+++ b/tutor/templates/local/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: {{ DOCKER_REGISTRY }}{{ DOCKER_IMAGE_OPENEDX }}
     volumes:
       - ../../data/openedx:/var/www/openedx
-    command: bash -c "rm -rf /var/www/openedx/staticfiles && cp -r /openedx/staticfiles/ /var/www/openedx/"
+    command: sh -c "rm -rf /var/www/openedx/staticfiles && cp -r /openedx/staticfiles/ /var/www/openedx/"
 
   nginx:
     image: {{ DOCKER_REGISTRY }}{{ DOCKER_IMAGE_NGINX }}

--- a/tutor/templates/scripts/create_databases.sh
+++ b/tutor/templates/scripts/create_databases.sh
@@ -1,4 +1,4 @@
-dockerize -wait tcp://{{ MYSQL_HOST }}:{{ MYSQL_PORT }} -timeout 20s
+while ! (tail /var/log/mysql/error.log |grep "ready for connections.">/dev/null); do sleep 1; done
 mysql -u root --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" -e 'CREATE DATABASE IF NOT EXISTS {{ OPENEDX_MYSQL_DATABASE }};'
 mysql -u root --password="{{ MYSQL_ROOT_PASSWORD }}" --host "{{ MYSQL_HOST }}" -e 'GRANT ALL ON {{ OPENEDX_MYSQL_DATABASE }}.* TO "{{ OPENEDX_MYSQL_USERNAME }}"@"%" IDENTIFIED BY "{{ OPENEDX_MYSQL_PASSWORD }}";'
 


### PR DESCRIPTION
Currently, for a newly created environment, `tutor local databases` will error out on the first run and succeed on the second one.

This is because the `mysql` container is started, and after it initialises its directories it's shut down.

So on the first run (when `os.path.exists(mysql_data_path)` is `False`) by the time code in `scripts.migrate` runs, the mysql container is stopped.

The PR also includes changes to not require the `mysql` client binary to be installed alongside openedx: it uses the client from the `mysql` container instead.

This PR is based on #208 